### PR TITLE
Feat/#23/설문 응답 결과 페이지 구현

### DIFF
--- a/Surbee/src/main/java/com/team5/surbee/controller/SurveyController.java
+++ b/Surbee/src/main/java/com/team5/surbee/controller/SurveyController.java
@@ -27,7 +27,6 @@ public class SurveyController {
         return "survey/create";
     }
 
-
     @PostMapping("/create")
     public String createSurvey(HttpSession httpSession, @ModelAttribute SurveyCreateRequest request) {
         SessionUserDto user = (SessionUserDto) httpSession.getAttribute("user");
@@ -64,4 +63,11 @@ public class SurveyController {
     }
 
 
+
+    @GetMapping("/{surveyId}/result")
+    public String getSurveyResult(@PathVariable Integer surveyId, Model model) {
+
+//        model.addAttribute("survey", survey);
+        return "result/stats";
+    }
 }

--- a/Surbee/src/main/java/com/team5/surbee/controller/SurveyController.java
+++ b/Surbee/src/main/java/com/team5/surbee/controller/SurveyController.java
@@ -66,8 +66,10 @@ public class SurveyController {
 
     @GetMapping("/{surveyId}/result")
     public String getSurveyResult(@PathVariable Integer surveyId, Model model) {
-
-//        model.addAttribute("survey", survey);
+//        log.info("Controller : 응답 결과 출력 (id = {})", surveyId);
+//        SurveyResultResponse response = surveyService.getSurveyResult(surveyId);
+//        model.addAttribute("survey", response);
+//        log.info("Controller : response = {})", response);
         return "result/stats";
     }
 }

--- a/Surbee/src/main/java/com/team5/surbee/dto/response/survey/OptionResultResponse.java
+++ b/Surbee/src/main/java/com/team5/surbee/dto/response/survey/OptionResultResponse.java
@@ -1,0 +1,9 @@
+package com.team5.surbee.dto.response.survey;
+
+public record OptionResultResponse(
+        Integer optionId,              // 옵션 ID
+        String optionText,             // 옵션 내용
+        Long count,                    // 해당 옵션 응답 수
+        Double rate                    // 전체 중 해당 옵션 선택 비율 (퍼센트)
+) {
+}

--- a/Surbee/src/main/java/com/team5/surbee/dto/response/survey/QuestionResultResponse.java
+++ b/Surbee/src/main/java/com/team5/surbee/dto/response/survey/QuestionResultResponse.java
@@ -1,0 +1,15 @@
+package com.team5.surbee.dto.response.survey;
+
+import com.team5.surbee.entity.constant.QuestionType;
+
+import java.util.List;
+
+public record QuestionResultResponse(
+        Integer id,                         // 질문 ID
+        String questionText,                // 질문 내용
+        QuestionType questionType,          // 질문 유형 (MULTIPLE_CHOICE, CHECKBOX, SHORT_ANSWER, LONG_ANSWER)
+        Long count,                         // 질문 응답 수
+        List<OptionResultResponse> options, // 객관식일 경우에만 사용
+        List<String> answers                // 주관식일 경우에만 사용
+) {
+}

--- a/Surbee/src/main/java/com/team5/surbee/dto/response/survey/SurveyOptionStat.java
+++ b/Surbee/src/main/java/com/team5/surbee/dto/response/survey/SurveyOptionStat.java
@@ -1,0 +1,8 @@
+package com.team5.surbee.dto.response.survey;
+
+public record SurveyOptionStat(
+        Integer optionId,
+        String optionText,
+        Long count
+) {
+}

--- a/Surbee/src/main/java/com/team5/surbee/dto/response/survey/SurveyResultResponse.java
+++ b/Surbee/src/main/java/com/team5/surbee/dto/response/survey/SurveyResultResponse.java
@@ -1,0 +1,11 @@
+package com.team5.surbee.dto.response.survey;
+
+import java.util.List;
+
+public record SurveyResultResponse(
+        Integer id,
+        String title,
+        String description,
+        List<QuestionResultResponse> questions
+) {
+}

--- a/Surbee/src/main/java/com/team5/surbee/entity/Answer.java
+++ b/Surbee/src/main/java/com/team5/surbee/entity/Answer.java
@@ -48,4 +48,8 @@ public class Answer {
     public static Answer optionAnswer(Question question, Option option, Submission submission) {
         return new Answer(question, option, null, submission);
     }
+
+    public void assignToSubmission(Submission submission) {
+        this.submission = submission;
+    }
 }

--- a/Surbee/src/main/java/com/team5/surbee/entity/Question.java
+++ b/Surbee/src/main/java/com/team5/surbee/entity/Question.java
@@ -40,6 +40,10 @@ public class Question {
     @ToString.Exclude
     private List<Option> options = new ArrayList<>();
 
+    @OneToMany(mappedBy = "question", cascade = CascadeType.ALL, orphanRemoval = true)
+    @ToString.Exclude
+    private List<Answer> answers = new ArrayList<>();
+
     private Question(String questionText, QuestionType questionType, Boolean isRequired, Survey survey, List<Option> options) {
         this.questionText = questionText;
         this.questionType = questionType;

--- a/Surbee/src/main/java/com/team5/surbee/repository/AnswerRepository.java
+++ b/Surbee/src/main/java/com/team5/surbee/repository/AnswerRepository.java
@@ -1,7 +1,29 @@
 package com.team5.surbee.repository;
 
+import com.team5.surbee.dto.response.survey.SurveyOptionStat;
 import com.team5.surbee.entity.Answer;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface AnswerRepository extends JpaRepository<Answer, Integer> {
+    @Query("""
+                SELECT new com.team5.surbee.dto.response.survey.SurveyOptionStat(
+                    o.id, o.optionText, COUNT(a.id)
+                )
+                FROM Answer a
+                JOIN a.option o
+                WHERE o.question.id = :questionId
+                GROUP BY o.id, o.optionText
+            """)
+    List<SurveyOptionStat> countAnswersByOption(@Param("questionId") Integer questionId);
+
+    @Query("""
+                SELECT a.answerText
+                FROM Answer a
+                WHERE a.question.id = :questionId AND a.answerText IS NOT NULL
+            """)
+    List<String> findTextAnswersByQuestionId(@Param("questionId") Integer questionId);
 }

--- a/Surbee/src/main/java/com/team5/surbee/repository/QuestionRepository.java
+++ b/Surbee/src/main/java/com/team5/surbee/repository/QuestionRepository.java
@@ -3,5 +3,8 @@ package com.team5.surbee.repository;
 import com.team5.surbee.entity.Question;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface QuestionRepository extends JpaRepository<Question, Integer> {
+    List<Question> findAllBySurveyId(Integer surveyId);
 }

--- a/Surbee/src/main/java/com/team5/surbee/repository/SurveyRepository.java
+++ b/Surbee/src/main/java/com/team5/surbee/repository/SurveyRepository.java
@@ -3,8 +3,11 @@ package com.team5.surbee.repository;
 import com.team5.surbee.entity.Survey;
 import com.team5.surbee.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface SurveyRepository extends JpaRepository<Survey, Integer> {
     List<Survey> findTop10ByIsClosedFalseOrderByCreatedAtDesc();
@@ -14,5 +17,8 @@ public interface SurveyRepository extends JpaRepository<Survey, Integer> {
     List<Survey> findTop10ByOrderBySubmissionCountDesc();
 
     List<Survey> findByUser(User user);
+
+    @Query("SELECT s FROM Survey s JOIN FETCH s.questions WHERE s.id = :id")
+    Optional<Survey> findByIdWithQuestions(@Param("id") Integer id);
 }
 

--- a/Surbee/src/main/resources/static/css/result-stat.css
+++ b/Surbee/src/main/resources/static/css/result-stat.css
@@ -1,0 +1,39 @@
+.chart-result-container {
+    width: 70%;
+    margin: 15px auto;
+}
+
+.text-result-container {
+    margin: 15px 5px;
+}
+
+.short-answer-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    padding: 0;
+    list-style: none;
+}
+
+.long-answer-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding-left: 0;
+    list-style: none;
+}
+
+.short-answer-item {
+    background-color: #f6f6f6;
+    padding: 12px 12px;
+    border-radius: 6px;
+    white-space: nowrap; /* 텍스트 줄바꿈 방지 */
+    display: inline-block;
+}
+
+.long-answer-item {
+    background-color: #f6f6f6;
+    padding: 12px 12px;
+    margin-bottom: 8px;
+    border-radius: 6px;
+}

--- a/Surbee/src/main/resources/static/css/survey-create.css
+++ b/Surbee/src/main/resources/static/css/survey-create.css
@@ -159,23 +159,6 @@ input:focus, textarea:focus {
     margin-bottom: 15px;
 }
 
-.result-container {
-    width: 70%;
-    margin: 15px auto;
-}
-
-.text-result-container {
-    margin: 15px 5px;
-}
-
-.text-answer-list {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-    list-style: none;
-    padding-left: 0;
-}
-
 .option {
     display: flex;
     justify-content: space-between;

--- a/Surbee/src/main/resources/static/css/survey-create.css
+++ b/Surbee/src/main/resources/static/css/survey-create.css
@@ -1,6 +1,7 @@
 * {
     box-sizing: border-box;
 }
+
 /* 공통 */
 input, textarea {
     border: 1px solid #DDDDDD;
@@ -28,9 +29,6 @@ input:focus, textarea:focus {
 .survey-container {
     padding: 20px;
     min-height: 100vh;
-}
-
-.survey-form {
     max-width: 800px;
     margin: 0 auto;
 }
@@ -40,7 +38,7 @@ input:focus, textarea:focus {
     border-radius: 0 0 10px 10px;
     padding: 20px;
     margin-bottom: 20px;
-    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
 }
 
 .empty-section {
@@ -51,7 +49,7 @@ input:focus, textarea:focus {
 }
 
 .survey-title {
-    width:  100%;
+    width: 100%;
     font-size: 25px;
     padding: 8px;
     margin-bottom: 10px;
@@ -98,7 +96,7 @@ input:focus, textarea:focus {
     border-radius: 10px;
     padding: 20px;
     margin-bottom: 20px;
-    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
 }
 
 .question-header {
@@ -161,6 +159,23 @@ input:focus, textarea:focus {
     margin-bottom: 15px;
 }
 
+.result-container {
+    width: 70%;
+    margin: 15px auto;
+}
+
+.text-result-container {
+    margin: 15px 5px;
+}
+
+.text-answer-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    list-style: none;
+    padding-left: 0;
+}
+
 .option {
     display: flex;
     justify-content: space-between;
@@ -171,6 +186,7 @@ input:focus, textarea:focus {
 .option .radio-label {
     flex: 1;
 }
+
 .option .checkbox-label {
     flex: 1;
 }
@@ -184,7 +200,7 @@ input:focus, textarea:focus {
 
 .delete-btn.hidden,
 .ai-btn.hidden {
-    visibility:  hidden;
+    visibility: hidden;
 }
 
 .text-input-container {
@@ -274,7 +290,7 @@ input:checked + .slider:before {
 }
 
 .add-question-btn,
-.delete-question-btn{
+.delete-question-btn {
     width: 40px;
     height: 40px;
     border-radius: 50%;
@@ -287,7 +303,7 @@ input:checked + .slider:before {
 }
 
 .delete-question-btn.hidden {
-    visibility:  hidden;
+    visibility: hidden;
 }
 
 .save-btn {

--- a/Surbee/src/main/resources/static/js/survey-result.js
+++ b/Surbee/src/main/resources/static/js/survey-result.js
@@ -1,0 +1,41 @@
+export function renderSurveyCharts(surveyData) {
+    surveyData.forEach((question, index) => {
+        if (!question.options) return;
+
+        const labels = question.options.map(o => o.optionText);
+        const data = question.options.map(o => o.count);
+
+        const ctxId = question.type === 'MULTIPLE_CHOICE'
+            ? `chart-pie-${index}`
+            : `chart-bar-${index}`;
+
+        const ctx = document.getElementById(ctxId);
+        if (!ctx) return;
+
+        const isPieChart = question.type === 'MULTIPLE_CHOICE';
+
+        new Chart(ctx, {
+            type: question.type === 'MULTIPLE_CHOICE' ? 'pie' : 'bar',
+            data: {
+                labels: labels,
+                datasets: [{
+                    label: '응답 수',
+                    data: data,
+                    backgroundColor: [
+                        '#f94144', '#f3722c', '#f8961e', '#f9c74f',
+                        '#90be6d', '#43aa8b', '#577590', '#277da1'
+                    ],
+                }]
+            },
+            options: {
+                responsive: true,
+                plugins: {
+                    legend: {
+                        display: isPieChart,
+                        position: 'bottom'
+                    }
+                }
+            }
+        });
+    });
+}

--- a/Surbee/src/main/resources/static/js/survey-result.js
+++ b/Surbee/src/main/resources/static/js/survey-result.js
@@ -5,17 +5,17 @@ export function renderSurveyCharts(surveyData) {
         const labels = question.options.map(o => o.optionText);
         const data = question.options.map(o => o.count);
 
-        const ctxId = question.type === 'MULTIPLE_CHOICE'
+        const ctxId = question.questionType === 'MULTIPLE_CHOICE'
             ? `chart-pie-${index}`
             : `chart-bar-${index}`;
 
         const ctx = document.getElementById(ctxId);
         if (!ctx) return;
 
-        const isPieChart = question.type === 'MULTIPLE_CHOICE';
+        const isPieChart = question.questionType === 'MULTIPLE_CHOICE';
 
         new Chart(ctx, {
-            type: question.type === 'MULTIPLE_CHOICE' ? 'pie' : 'bar',
+            type: question.questionType === 'MULTIPLE_CHOICE' ? 'pie' : 'bar',
             data: {
                 labels: labels,
                 datasets: [{

--- a/Surbee/src/main/resources/templates/result/stats.html
+++ b/Surbee/src/main/resources/templates/result/stats.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html layout:decorate="~{layout/layout}"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>설문 결과 : Surbee</title>
+    <link rel="stylesheet" th:href="@{/css/survey-create.css}"/>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+<section layout:fragment="content">
+    <div class="survey-container">
+        <!-- 설문지 제목/설명 -->
+        <div class="empty-section"></div>
+        <div class="survey-header">
+            <div class="title-section">
+                <h1 th:text="${survey.title}">설문지 제목</h1>
+                <p th:text="${survey.description}">설문지 설명</p>
+            </div>
+        </div>
+
+        <!-- 질문 목록 -->
+        <div class="questions-container" th:each="question : ${survey.questions}">
+            <div class="question-box">
+                <div class="question-header">
+                    <h2 th:text="${question.questionText}">질문 제목</h2>
+                    <p th:text="'응답 수: ' + ${question.submissionCount}"></p>
+                </div>
+                <!-- 객관식 -->
+                <div class="result-container"
+                     th:if="${question.type == 'MULTIPLE_CHOICE'}">
+                    <canvas th:id="'chart-pie-' + ${questionStat.index}"></canvas>
+                </div>
+
+                <!-- 체크박스 -->
+                <div class="result-container"
+                     th:if="${question.type == 'CHECKBOX'}">
+                    <canvas th:id="'chart-bar-' + ${questionStat.index}"></canvas>
+                </div>
+                <!-- 주관식 -->
+                <div class="text-result-container"
+                     th:if="${question.type == 'SHORT_ANSWER' or question.type == 'LONG_ANSWER'}">
+                    <ul class="text-answer-list">
+                        <li th:each="answer : ${question.answers}" th:text="${answer}"></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <!-- 질문 추가 및 저장 버튼 -->
+        <div class="form-actions">
+            <button class="delete-question-btn hidden" type="button">
+                <i class="fas fa-minus"></i>
+            </button>
+            <button class="add-question-btn" type="button">
+                <i class="fas fa-plus"></i>
+            </button>
+            <button class="save-btn" type="submit">저장</button>
+        </div>
+    </div>
+
+    <!-- Font Awesome 아이콘 -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" rel="stylesheet">
+    <!-- survey-result.js 불러오기 -->
+    <script th:src="@{/js/survey-result.js}" type="module"></script>
+    <!-- 초기화 코드 -->
+    <script th:inline="javascript" type="module">
+        import {renderSurveyCharts} from '/js/survey-result.js';
+
+        /*<![CDATA[*/
+        const surveyData = /*[[${survey.questions}]]*/ [];
+        renderSurveyCharts(surveyData);
+        /*]]>*/
+    </script>
+</section>
+</body>
+</html>

--- a/Surbee/src/main/resources/templates/result/stats.html
+++ b/Surbee/src/main/resources/templates/result/stats.html
@@ -6,6 +6,7 @@
     <meta charset="UTF-8">
     <title>설문 결과 : Surbee</title>
     <link rel="stylesheet" th:href="@{/css/survey-create.css}"/>
+    <link rel="stylesheet" th:href="@{/css/result-stat.css}"/>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>
@@ -19,54 +20,45 @@
                 <p th:text="${survey.description}">설문지 설명</p>
             </div>
         </div>
-
         <!-- 질문 목록 -->
-        <div class="questions-container" th:each="question : ${survey.questions}">
+        <div class="questions-container" th:each="question, questionStat : ${survey.questions}">
             <div class="question-box">
                 <div class="question-header">
                     <h2 th:text="${question.questionText}">질문 제목</h2>
-                    <p th:text="'응답 수: ' + ${question.submissionCount}"></p>
+                    <p th:text="'응답 수: ' + ${question.count}"></p>
                 </div>
                 <!-- 객관식 -->
-                <div class="result-container"
-                     th:if="${question.type == 'MULTIPLE_CHOICE'}">
+                <div class="chart-result-container"
+                     th:if="${question.questionType.name == 'MULTIPLE_CHOICE'}">
                     <canvas th:id="'chart-pie-' + ${questionStat.index}"></canvas>
                 </div>
-
                 <!-- 체크박스 -->
-                <div class="result-container"
-                     th:if="${question.type == 'CHECKBOX'}">
+                <div class="chart-result-container"
+                     th:if="${question.questionType.name == 'CHECKBOX'}">
                     <canvas th:id="'chart-bar-' + ${questionStat.index}"></canvas>
                 </div>
-                <!-- 주관식 -->
+                <!-- 단답형 -->
                 <div class="text-result-container"
-                     th:if="${question.type == 'SHORT_ANSWER' or question.type == 'LONG_ANSWER'}">
-                    <ul class="text-answer-list">
-                        <li th:each="answer : ${question.answers}" th:text="${answer}"></li>
+                     th:if="${question.questionType.name == 'SHORT_ANSWER'}">
+                    <ul class="short-answer-list">
+                        <li class="short-answer-item" th:each="answer : ${question.answers()}" th:text="${answer}"></li>
+                    </ul>
+                </div>
+                <!-- 장문형 -->
+                <div class="text-result-container"
+                     th:if="${question.questionType.name == 'LONG_ANSWER'}">
+                    <ul class="long-answer-list">
+                        <li class="long-answer-item" th:each="answer : ${question.answers()}" th:text="${answer}"></li>
                     </ul>
                 </div>
             </div>
         </div>
-        <!-- 질문 추가 및 저장 버튼 -->
-        <div class="form-actions">
-            <button class="delete-question-btn hidden" type="button">
-                <i class="fas fa-minus"></i>
-            </button>
-            <button class="add-question-btn" type="button">
-                <i class="fas fa-plus"></i>
-            </button>
-            <button class="save-btn" type="submit">저장</button>
-        </div>
     </div>
-
-    <!-- Font Awesome 아이콘 -->
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" rel="stylesheet">
     <!-- survey-result.js 불러오기 -->
     <script th:src="@{/js/survey-result.js}" type="module"></script>
     <!-- 초기화 코드 -->
     <script th:inline="javascript" type="module">
         import {renderSurveyCharts} from '/js/survey-result.js';
-
         /*<![CDATA[*/
         const surveyData = /*[[${survey.questions}]]*/ [];
         renderSurveyCharts(surveyData);

--- a/Surbee/src/main/resources/templates/survey/create.html
+++ b/Surbee/src/main/resources/templates/survey/create.html
@@ -1,38 +1,38 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org"
+<html layout:decorate="~{layout/layout}"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-      layout:decorate="~{layout/layout}">
+      xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
     <title>설문 생성 : Surbee</title>
-    <link rel="stylesheet" th:href="@{/css/survey-create.css}" />
+    <link rel="stylesheet" th:href="@{/css/survey-create.css}"/>
 </head>
 <body>
 <section layout:fragment="content">
     <div class="survey-container">
-        <form class="survey-form" th:action="@{/surveys/create}" th:method="post" th:object="${survey}">
+        <form th:action="@{/surveys/create}" th:method="post" th:object="${survey}">
             <!-- 설문지 제목/설명 -->
             <div class="empty-section"></div>
             <div class="survey-header">
                 <div class="title-section">
-                    <input type="text" class="survey-title" name="title" placeholder="설문지 제목">
+                    <input class="survey-title" name="title" placeholder="설문지 제목" type="text">
                     <textarea class="survey-description" name="description"
                               placeholder="설문지 설명" rows="2"></textarea>
                 </div>
                 <div class="privacy-section">
                     <div class="privacy-options">
                         <label class="radio-label">
-                            <input type="radio" name="privacy" value="PUBLIC" checked>
+                            <input checked name="privacy" type="radio" value="PUBLIC">
                             <span>공개</span>
                         </label>
                         <label class="radio-label">
-                            <input type="radio" name="privacy" value="PRIVATE">
+                            <input name="privacy" type="radio" value="PRIVATE">
                             <span>비공개</span>
                         </label>
                     </div>
                     <div class="password-input">
                         <label for="password">비밀번호</label>
-                        <input type="password" disabled id="password" name="password">
+                        <input disabled id="password" name="password" type="password">
                     </div>
                 </div>
             </div>
@@ -41,10 +41,10 @@
             <div class="questions-container" id="questions-container">
                 <div class="question-box">
                     <div class="question-header">
-                        <input type="text" class="question-text" name="questions[0].questionText" placeholder="질문">
+                        <input class="question-text" name="questions[0].questionText" placeholder="질문" type="text">
                         <div class="question-type">
                             <select class="form-select" name="questions[0].type">
-                                <option value="MULTIPLE_CHOICE" selected>객관식</option>
+                                <option selected value="MULTIPLE_CHOICE">객관식</option>
                                 <option value="CHECKBOX">체크박스</option>
                                 <option value="SHORT_ANSWER">단답형</option>
                                 <option value="LONG_ANSWER">장문형</option>
@@ -55,9 +55,9 @@
                     <div class="options-container" id="options-container-0">
                         <div class="option">
                             <label class="radio-label">
-                                <input type="radio" disabled>
-                                <input type="text" class="text-input"
-                                       name="questions[0].options[0].optionText" value="옵션 1">
+                                <input disabled type="radio">
+                                <input class="text-input" name="questions[0].options[0].optionText"
+                                       type="text" value="옵션 1">
                             </label>
                             <button class="delete-btn hidden" type="button">
                                 <i class="fas fa-trash"></i>
@@ -65,7 +65,7 @@
                         </div>
                         <div class="option add-option" id="add-option-btn">
                             <label class="radio-label">
-                                <input type="radio" disabled>
+                                <input disabled type="radio">
                                 <span>옵션 추가</span>
                             </label>
                         </div>
@@ -75,7 +75,7 @@
                         <div class="required-toggle">
                             <span>필수</span>
                             <label class="switch">
-                                <input type="checkbox" name="questions[0].isRequired">
+                                <input name="questions[0].isRequired" type="checkbox">
                                 <span class="slider round"></span>
                             </label>
                         </div>
@@ -84,20 +84,20 @@
             </div>
             <!-- 질문 추가 및 저장 버튼 -->
             <div class="form-actions">
-                <button type="button" class="delete-question-btn hidden">
+                <button class="delete-question-btn hidden" type="button">
                     <i class="fas fa-minus"></i>
                 </button>
-                <button type="button" class="add-question-btn">
+                <button class="add-question-btn" type="button">
                     <i class="fas fa-plus"></i>
                 </button>
-                <button type="submit" class="save-btn">저장</button>
+                <button class="save-btn" type="submit">저장</button>
             </div>
         </form>
     </div>
 
     <!-- Font Awesome 아이콘 -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
-    <script type="module" th:src="@{/js/survey-create.js}"></script>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" rel="stylesheet">
+    <script th:src="@{/js/survey-create.js}" type="module"></script>
 </section>
 </body>
 </html>

--- a/Surbee/src/test/java/com/team5/surbee/service/SurveyResultTest.java
+++ b/Surbee/src/test/java/com/team5/surbee/service/SurveyResultTest.java
@@ -1,0 +1,114 @@
+package com.team5.surbee.service;
+
+import com.team5.surbee.common.exception.ErrorCode;
+import com.team5.surbee.common.exception.UserExcpetion;
+import com.team5.surbee.dto.response.survey.SurveyResultResponse;
+import com.team5.surbee.entity.*;
+import com.team5.surbee.entity.constant.QuestionType;
+import com.team5.surbee.repository.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+@Transactional
+@Rollback(false)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class SurveyResultTest {
+
+    @Autowired
+    private SurveyRepository surveyRepository;
+    @Autowired
+    private QuestionRepository questionRepository;
+    @Autowired
+    private OptionRepository optionRepository;
+    @Autowired
+    private SubmissionRepository submissionRepository;
+    @Autowired
+    private AnswerRepository answerRepository;
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private SurveyService surveyService;
+
+    private Survey survey;
+
+    @BeforeEach
+    void setUp() {
+        // 사용자 생성
+        User user = userRepository.findById(1).orElseThrow(() -> new UserExcpetion(ErrorCode.USER_NOT_FOUND));
+
+        // 설문 + 질문 + 옵션 세팅
+        survey = Survey.of(
+                "프로그래밍 선호도 조사",
+                "개발자 대상으로 선호 기술 조사",
+                true,
+                null,
+                user,
+                new ArrayList<>()
+        );
+        survey = surveyRepository.save(survey);
+
+        // 질문 4개: MC / CHECKBOX / SHORT / LONG
+        for (QuestionType type : QuestionType.values()) {
+            Question q = Question.of("질문 - " + type.name(), type, true, survey, new ArrayList<>());
+            q = questionRepository.save(q);
+            survey.getQuestions().add(q);
+            // 객관식 질문에는 옵션 추가
+            if (type == QuestionType.MULTIPLE_CHOICE || type == QuestionType.CHECKBOX) {
+                for (int i = 1; i <= 3; i++) {
+                    Option opt = Option.of("옵션 " + i, q);
+                    q.getOptions().add(opt);
+                    optionRepository.save(opt);
+                }
+            }
+        }
+    }
+
+    @Test
+    void generateDummyResponsesAndTestSurveyResult() {
+        List<Question> questions = questionRepository.findAllBySurveyId(survey.getId());
+
+        for (int i = 0; i < 100; i++) {
+            List<Answer> answers = new ArrayList<>();
+
+            for (Question q : questions) {
+                if (q.getQuestionType() == QuestionType.MULTIPLE_CHOICE || q.getQuestionType() == QuestionType.CHECKBOX) {
+                    // 무작위 옵션 선택
+                    List<Option> options = q.getOptions();
+                    Option randomOption = options.get(i % options.size());
+                    answers.add(Answer.optionAnswer(q, randomOption, null));
+                } else {
+                    // 주관식 응답
+                    answers.add(Answer.textAnswer(q, "응답 내용 #" + i, null));
+                }
+            }
+
+            Submission s = Submission.of(1, survey, answers); // userId = 1
+            submissionRepository.save(s);
+
+            // submission을 각 answer에 set (역참조)
+            for (Answer a : answers) {
+                a.assignToSubmission(s);
+                answerRepository.save(a);
+            }
+        }
+
+        // 실제 서비스 로직 테스트
+        SurveyResultResponse result = surveyService.getSurveyResult(survey.getId());
+
+        // 결과 검증
+        assertEquals(4, result.questions().size());
+        System.out.println(result);
+    }
+}


### PR DESCRIPTION
## ✅ 요약
설문 응답 결과를 시각적으로 확인할 수 있는 결과 페이지를 구현했습니다.  
차트(원형, 막대) 및 주관식 답변 리스트가 반영된 응답 통계를 제공합니다.

## 🧩 변경 내용
- `SurveyResultResponse`, `QuestionResultResponse`, `OptionResultResponse` 등 DTO 추가
- `/surveys/{id}/result` 경로에 대한 Controller/Service 로직 추가
- 응답 결과 페이지 템플릿 `stats.html` 생성 및 Thymeleaf 뷰 연결
- Chart.js를 이용한 원형/막대 그래프 렌더링 (객관식/체크박스)
- 주관식 응답에 대한 리스트 출력
- 테스트용 `SurveyResultTest` 클래스 작성 (표본 응답 100건)

## 🔍 확인 필요사항
- 다양한 설문 형태(MC/Checkbox/Short/Long)에 대한 응답이 제대로 렌더링되는지 확인 필요
- 실제 데이터베이스 기반 설문으로 페이지 연동 테스트 필요

## 📝 메모
- 선택지별 응답 비율 계산 로직 반올림 적용 (소수점 1자리)
- 추후 결과 페이지에 분석 지표 추가 가능성 있음
- 테스트 코드에서 사용되는 userId(1)는 실제 존재하는 사용자와 일치해야 함